### PR TITLE
Fix deprecated GitHub Actions: update to v4/v5

### DIFF
--- a/.github/workflows/deploy-hf-spaces.yml
+++ b/.github/workflows/deploy-hf-spaces.yml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0  # Fetch full history for proper Git operations
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -42,7 +42,7 @@ jobs:
         fetch-depth: 0
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
@@ -126,7 +126,7 @@ jobs:
         fi
     
     - name: Upload model checkpoints
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: model-checkpoints-${{ env.MODEL_SIZE }}-${{ github.run_number }}
         path: |
@@ -135,7 +135,7 @@ jobs:
         retention-days: 30
     
     - name: Upload training logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: training-logs-${{ github.run_number }}
         path: |


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4
- Update actions/setup-python from v4 to v5
- Resolves deprecation warnings in workflows